### PR TITLE
feat: add schemas related to sr search

### DIFF
--- a/src/core/schemas/__init__.py
+++ b/src/core/schemas/__init__.py
@@ -1,0 +1,167 @@
+"""Core domain models."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Annotated, Any, Literal
+
+import uuid6
+from pydantic import BaseModel, Field
+from pydantic.types import StringConstraints
+
+CriterionType = Literal["inclusion", "exclusion"]
+
+ScreeningResult = Literal["include", "exclude", "uncertain"]
+
+
+class Criterion(BaseModel):
+    """A criterion for including or excluding a paper."""
+
+    description: Annotated[str, StringConstraints(min_length=1)]
+    type: CriterionType
+    rationale: str | None = None
+
+
+class ResearchQuestion(BaseModel):
+    """The research question."""
+
+    id: uuid6.UUID = Field(default_factory=uuid6.uuid7)
+    question: Annotated[str, StringConstraints(min_length=1)]
+    review_criteria: ReviewCriteria
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+
+
+class ReviewCriteria(BaseModel):
+    """The review criteria."""
+
+    inclusion: list[Criterion] = Field(..., min_length=1)
+    exclusion: list[Criterion] = Field(default=[], min_length=0)
+
+
+class ScreeningDecision(BaseModel):
+    """A decision made by a reviewer."""
+
+    id: uuid6.UUID = Field(default_factory=uuid6.uuid7)
+    srid: uuid6.UUID
+    docid: uuid6.UUID | str | int
+    result: ScreeningResult
+    confidence: float = Field(ge=0.0, le=1.0)
+    reasons: list[str]
+    model_id: str | None = Field(
+        default=None,
+        description="The ID of the model that made the decision",
+        examples=["claude-3-5-sonnet-latest", "gpt-4o"],
+    )
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+
+
+class PaperMetadata(BaseModel):
+    """Metadata for a paper."""
+
+    pmid: str = Field(..., pattern=r"^\d{8}$")
+    title: str
+    abstract: str
+    authors: list[str] | None = None
+    publication_year: int = Field(gt=1900, lt=2100)
+    journal: str
+    mesh_terms: list[str] | None = None
+
+
+# RAG Models
+class SearchConfig(BaseModel):
+    max_chunks: int = Field(default=5, gt=0)
+    min_relevance: float = Field(default=0.7, ge=0.0, le=1.0)
+    model_name: str = "BAAI/bge-large-en"
+
+
+class ChunkMetadata(BaseModel):
+    paper_id: str
+    section: str
+    section_level: int = Field(ge=0)
+    chunk_index: int = Field(ge=0)
+    token_count: int = Field(gt=0)
+    embedding_model: str
+
+
+class SearchResult(BaseModel):
+    text: str
+    section: str
+    relevance: float = Field(ge=0.0, le=1.0)
+    metadata: ChunkMetadata
+
+
+# PRISMA Models
+class PrismaSection(BaseModel):
+    count: int = Field(ge=0)
+    details: dict[str, int] = {}
+    notes: str | None = None
+
+
+class PrismaState(BaseModel):
+    version: int = Field(ge=1)
+    timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    database_records: PrismaSection
+    register_records: PrismaSection
+    other_sources: PrismaSection
+    duplicates: PrismaSection
+    automated_exclusions: PrismaSection
+    records_screened: PrismaSection
+    records_excluded: PrismaSection
+    full_text_assessed: PrismaSection
+    studies_included: PrismaSection
+
+    class Config:
+        json_schema_extra = {
+            "example": {
+                "version": 1,
+                "database_records": {
+                    "count": 1200,
+                    "details": {"PubMed": 800, "Scopus": 400},
+                },
+            }
+        }
+
+
+# Event Models
+class ReviewEvent(BaseModel):
+    event_type: str
+    review_id: uuid6.UUID
+    user_id: str
+    timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    data: dict[str, Any] | None = None
+
+
+class CriteriaUpdated(ReviewEvent):
+    event_type: Literal["criteria_updated"] = "criteria_updated"
+    data: dict[str, type[ReviewCriteria] | str] = {
+        "old_criteria": ReviewCriteria,
+        "new_criteria": ReviewCriteria,
+        "reason": str,
+    }
+
+
+# Queue Job Models
+
+JobType = Literal["chunk_embed", "index_update"]
+
+
+class ProcessingJob(BaseModel):
+    """Processing job."""
+
+    pmid: str = Field(..., pattern=r"^\d{8}$")
+    project_id: uuid6.UUID
+    job_type: JobType
+    payload: dict[str, Any]
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+
+    class Config:
+        json_schema_extra = {
+            "example": {
+                "paper_id": "PMC123456",
+                "job_type": "chunk_embed",
+                "priority": 1,
+                "payload": {"model": "BAAI/bge-large-en", "chunk_size": 512},
+            }
+        }

--- a/src/core/schemas/search.py
+++ b/src/core/schemas/search.py
@@ -1,0 +1,243 @@
+"""Schemas related to search in the context of systematic reviews."""
+
+from __future__ import annotations
+
+from enum import StrEnum, auto
+from typing import Annotated
+
+from pydantic import BaseModel, Field
+
+
+class DatabaseType(StrEnum):
+    """Classifies academic and scientific databases by their primary content type.
+
+    This classification helps determine appropriate search strategies and expected
+    content types. While databases may serve multiple purposes, we designate the
+    primary type here for systematic review planning.
+
+    See Also:
+        :class:`DatabasePlatform`: For information about access platforms.
+        `Systematic Review Types <https://www.cochranelibrary.com/about/about-cochrane-reviews>`_
+    """
+
+    BIBLIOGRAPHIC = auto()
+    """Standard bibliographic databases containing primarily journal articles and conference proceedings."""
+
+    CLINICAL_TRIALS = auto()
+    """Specialized databases focused on clinical trial registrations and results."""
+
+    GREY_LITERATURE = auto()
+    """Sources for conference abstracts, dissertations, and other non-journal content."""
+
+    CITATION_INDEX = auto()
+    """Citation-focused databases that track article references and citations."""
+
+    def _generate_next_value_(name: str, *_) -> str:
+        return name.lower()
+
+
+class DatabasePlatform(StrEnum):
+    """Platform interfaces through which databases can be accessed.
+
+    In academic/scientific database access, the same database content may be available
+    through different platforms. Each platform has unique characteristics affecting:
+        * Search syntax and capabilities
+        * Field codes and operators
+        * Authentication methods
+        * Rate limits and quotas
+        * Results format and export options
+
+    Examples:
+        * MEDLINE content via PubMed (native) vs Ovid platforms
+        * PsycINFO accessed through Ovid vs EBSCO interfaces
+
+    Note:
+        Platform choice can significantly impact systematic review methodology due to
+        differences in search syntax and capabilities.
+    """
+
+    NATIVE = auto()
+    """Database's own platform (e.g., PubMed interface for MEDLINE content)."""
+
+    OVID = auto()
+    """Wolters Kluwer's Ovid platform, known for advanced search syntax and medical focus.
+
+    See Also:
+        `Ovid Syntax Guide <https://ospguides.ovid.com/OSPguides/medline.htm>`_
+    """
+
+    EBSCO = auto()
+    """EBSCO platform, widely used in academic libraries, supports multiple databases."""
+
+    PROQUEST = auto()
+    """ProQuest platform, common in academic institutions, strong in social sciences."""
+
+    WILEY = auto()
+    """Wiley Online Library, primary access point for Cochrane Library and Wiley content."""
+
+    def _generate_next_value_(name: str, *_) -> str:
+        return name.lower()
+
+    @property
+    def display_name(self) -> str:
+        """Returns human-readable platform name with proper capitalization.
+
+        Returns:
+            str: Formatted display name for UI presentation.
+        """
+        display_names = {
+            DatabasePlatform.NATIVE: "Native Interface",
+            DatabasePlatform.OVID: "Ovid",
+            DatabasePlatform.EBSCO: "EBSCO",
+            DatabasePlatform.PROQUEST: "ProQuest",
+            DatabasePlatform.WILEY: "Wiley Online Library",
+        }
+        return display_names[self]
+
+
+class FieldType(StrEnum):
+    """Classifies database search fields for cross-platform compatibility.
+
+    This classification system enables:
+        * Field mapping between different databases
+        * Query translation between platforms
+        * Standardized search strategy development
+        * Consistent results processing
+
+    Note:
+        Different platforms often use varying field codes for the same concept.
+        For example, title searches might use:
+            * PubMed: [ti]
+            * Ovid: .ti
+            * EBSCO: TI
+
+    See Also:
+        :class:`SearchField`: For field implementation details.
+    """
+
+    TITLE = auto()
+    """Article title field, typically high-precision search target."""
+
+    ABSTRACT = auto()
+    """Abstract text, important for comprehensive searching."""
+
+    KEYWORD = auto()
+    """Author-assigned keywords or uncontrolled terms."""
+
+    CONTROLLED_VOCAB = auto()
+    """Controlled vocabulary terms (e.g., MeSH, Emtree) for precise subject searching."""
+
+    PUBLICATION_TYPE = auto()
+    """Document type classification (e.g., review, clinical trial, meta-analysis)."""
+
+    AUTHOR = auto()
+    """Author name fields for author-specific searches."""
+
+    JOURNAL = auto()
+    """Source publication name for journal-specific searches."""
+
+    YEAR = auto()
+    """Publication year for date-range limitations."""
+
+    LANGUAGE = auto()
+    """Publication language for language-specific filtering."""
+
+    ALL = auto()
+    """Multi-field search across multiple fields (implementation varies by platform)."""
+
+    def _generate_next_value_(name: str, *_) -> str:
+        return name.lower()
+
+
+class SearchField(BaseModel):
+    """Represents a searchable field in a database with platform-specific details.
+
+    Search fields vary by database and platform, with the same conceptual field
+    potentially having different syntax across platforms.
+
+    Examples:
+        Title field syntax variations:
+            * PubMed: cancer[ti]
+            * Ovid: cancer.ti
+            * EBSCO: TI cancer
+
+    Note:
+        Field behavior may vary across platforms even when syntax is similar.
+
+    See Also:
+        :class:`FieldType`: For field type classification details.
+        :class:`DatabasePlatform`: For platform-specific information.
+    """
+
+    code: Annotated[
+        str,
+        Field(
+            description="Field code used in search syntax",
+            examples=["[ti]", ".ti", "TI"],
+            title="Field Code",
+        ),
+    ]
+    name: Annotated[
+        str,
+        Field(
+            description="Human-readable field name",
+            examples=["Title", "Abstract", "MeSH Terms"],
+            title="Field Name",
+        ),
+    ]
+    description: Annotated[
+        str,
+        Field(
+            description="Detailed description of the field's purpose and usage",
+            examples=["Search within article titles only"],
+            title="Field Description",
+        ),
+    ]
+    field_type: Annotated[
+        FieldType,
+        Field(
+            description="Classification of the field type for cross-database mapping",
+            title="Field Type",
+        ),
+    ]
+    is_controlled_vocabulary: Annotated[
+        bool,
+        Field(
+            default=False,
+            description="Indicates if the field uses a controlled vocabulary (e.g., MeSH, Emtree)",
+            title="Is Controlled Vocabulary",
+        ),
+    ]
+    platforms: Annotated[
+        set[DatabasePlatform],
+        Field(
+            default_factory=lambda: {DatabasePlatform.NATIVE},
+            description="Platforms where this field code is valid",
+            title="Valid Platforms",
+        ),
+    ]
+    syntax_examples: Annotated[
+        list[str],
+        Field(
+            default_factory=list,
+            description="Examples of valid syntax for this field",
+            examples=["cancer[ti]", "neoplasm*[ti]"],
+            title="Syntax Examples",
+        ),
+    ]
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [
+                {
+                    "code": "[ti]",
+                    "name": "Title",
+                    "description": "Search within article titles only",
+                    "field_type": "title",
+                    "is_controlled_vocabulary": False,
+                    "platforms": ["native"],
+                    "syntax_examples": ["cancer[ti]", "neoplasm*[ti]"],
+                }
+            ]
+        }
+    }


### PR DESCRIPTION
These schemas and types relate to search strategy, managing searches during SR, and source databases.

They are documented with TypeScript client SDK generation and FastAPI OpenAPI 3.1 definition in mind to ensure high-quality generated code and API and backend documentation.

The SQLModel database schema models for search follow soon. This module can be pasted for AI as an example of how to use enums and Pydantic and document them properly. Having AI include domain knowledge in code comments helps devs who often are unfamiliar with non-technical domains.